### PR TITLE
fox lb monitor error create tcp

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -27,11 +27,22 @@ resource "openstack_lb_listener_v2" "listener" {
 }
 
 resource "openstack_lb_monitor_v2" "lb_monitor" {
+  count = var.monitor_tcp == false ? 1 : 0
   name           = "${var.name}-lb_monitor"
   pool_id        = openstack_lb_pool_v2.lb_pool.id
   type           = var.lb_pool_protocol
   url_path       = var.monitor_url_path
   expected_codes = var.monitor_expected_codes
+  delay          = var.monitor_delay
+  timeout        = var.monitor_timeout
+  max_retries    = var.monitor_max_retries
+}
+
+resource "openstack_lb_monitor_v2" "lb_monitor_tcp" {
+  count = var.monitor_tcp == true ? 1 : 0
+  name           = "${var.name}-lb_monitor"
+  pool_id        = openstack_lb_pool_v2.lb_pool.id
+  type           = var.lb_pool_protocol
   delay          = var.monitor_delay
   timeout        = var.monitor_timeout
   max_retries    = var.monitor_max_retries

--- a/vars.tf
+++ b/vars.tf
@@ -62,10 +62,15 @@ variable "lb_pool_protocol" {
   default     = "HTTP"
 }
 
-
 ###########
 # Monitor #
 ###########
+variable "monitor_tcp" {
+  description = "Disable url_path and expected_codes if monitor type TCP"
+  type        = bool
+  default     = false
+}
+
 variable "monitor_url_path" {
   description = "Required for HTTP(S) types. URI path that will be accessed if monitor type is HTTP or HTTPS"
   type        = string


### PR DESCRIPTION
Example for playback  
```
module "lb-api" {
  source           = "git::https://github.com/thobiast/terraform-openstack-loadbalancer.git"
  name             = "test-tcp"
  lb_description   = "Test load balancer using terraform module"
  lb_vip_subnet_id = module.nat.subnet_id

  monitor_tcp = true

  listener_protocol      = "TCP"
  listener_protocol_port = "6443"

  lb_pool_protocol = "TCP"
  member_port      = "6443"
  member_address   = module.k8s-masters.access_ip_v4
  member_subnet_id = module.nat.subnet_id
}
```
Error:  
```
Error: Unable to create openstack_lb_monitor_v2: Bad request with: [POST https://api.ru-7.selvpc.ru/load-balancer/v2.0/lbaas/healthmonitors], error message: {"debuginfo": null, "faultcode": "Client", "faultstring": "url_path is not a valid option for health monitors of type TCP"}

  on .terraform/modules/lb-api/main.tf line 29, in resource "openstack_lb_monitor_v2" "lb_monitor":
  29: resource "openstack_lb_monitor_v2" "lb_monitor" {



Error: Unable to create openstack_lb_monitor_v2: Bad request with: [POST https://api.ru-7.selvpc.ru/load-balancer/v2.0/lbaas/healthmonitors], error message: {"debuginfo": null, "faultcode": "Client", "faultstring": "expected_codes is not a valid option for health monitors of type TCP"}

  on .terraform/modules/lb-api/main.tf line 41, in resource "openstack_lb_monitor_v2" "lb_monitor_tcp":
  41: resource "openstack_lb_monitor_v2" "lb_monitor_tcp" {

```