### PR TITLE
Proxy protocol

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Terraform init
         run: terraform init
       - name: Terraform format
-        run: terraform fmt -check
+        run: terraform fmt -diff -check
       - name: Terraform validate
         run: terraform validate

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ locals {
 # monitor has different parameters to http* and tcp
 # Create non TCP monitor
 resource "openstack_lb_monitor_v2" "lb_monitor" {
-  for_each = { for k, r in var.listeners : k => r if !contains(local.non_http, r["lb_pool_protocol"]) }
+  for_each = { for k, r in var.listeners : k => r if ! contains(local.non_http, r["lb_pool_protocol"]) }
 
   pool_id          = openstack_lb_pool_v2.lb_pool[each.key].id
   name             = lookup(each.value, "monitor_name", format("%s-%s-%s", var.name, each.key, "lb_monitor"))


### PR DESCRIPTION
I found a bug when I create a pool with the `PROXY` protocol. Then the pool protocol collides with OpenStack:

```
│ Error: expected type to be one of [TCP UDP-CONNECT HTTP HTTPS TLS-HELLO PING], got PROXY
│ 
│   with module.customer-lb[0].openstack_lb_monitor_v2.lb_monitor_tcp["http_customer"],
│   on .terraform/modules/customer-lb/main.tf line 75, in resource "openstack_lb_monitor_v2" "lb_monitor_tcp":
│   75: resource "openstack_lb_monitor_v2" "lb_monitor_tcp" {
│ 
╵
╷
│ Error: expected type to be one of [TCP UDP-CONNECT HTTP HTTPS TLS-HELLO PING], got PROXY
│ 
│   with module.customer-lb[0].openstack_lb_monitor_v2.lb_monitor_tcp["https_customer"],
│   on .terraform/modules/customer-lb/main.tf line 75, in resource "openstack_lb_monitor_v2" "lb_monitor_tcp":
│   75: resource "openstack_lb_monitor_v2" "lb_monitor_tcp" {
```

So in this case, instead of using the `PROXY` protocol from the pool, I am using the listeners now.